### PR TITLE
Added EOF new line to fix conf parse error.

### DIFF
--- a/etc/raspindi.conf.default
+++ b/etc/raspindi.conf.default
@@ -13,3 +13,4 @@ fps="25";
 # meteringmode: "average"; // Options: average, spot, backlit, matrix, max
 # rotation: 0; // Options: 0, 90, 180, 270
 # mirror: "none"; // Options: none, horizontal, vertical, both
+


### PR DESCRIPTION
I was getting a conf parsing error when running `/opt/raspindi/raspindi.sh`. 

I popped a newline at the end of the file and `/opt/raspindi/raspindi.sh` no longer complained about the parsing error.